### PR TITLE
swiftな感じにリファクタリング

### DIFF
--- a/Example/LocationPickerController/ViewController.swift
+++ b/Example/LocationPickerController/ViewController.swift
@@ -28,8 +28,7 @@ class ViewController: UIViewController {
             [weak self] (coordinate: CLLocationCoordinate2D) -> Void in
             self?.locationLabel.text = "".stringByAppendingFormat("%.4f, %.4f",
                 coordinate.latitude, coordinate.longitude)
-            },
-                                                      failure: nil)
+            })
         let navigationController = UINavigationController(rootViewController: viewController)
         self.presentViewController(navigationController, animated: true, completion: nil)
     }

--- a/LocationPickerController/LocationPickerController.swift
+++ b/LocationPickerController/LocationPickerController.swift
@@ -95,17 +95,13 @@ class LocationPickerController: UIViewController, MKMapViewDelegate, CLLocationM
 
     func didTapDoneButton() {
         guard CLLocationCoordinate2DIsValid(self.mapView.centerCoordinate) else {
-            if let failure = self.failure {
-                failure(NSError(domain: "LocationPickerControllerErrorDomain",
-                    code: 0,
-                    userInfo: ["Reason": "Invalid coordinate"]))
-            }
+            self.failure?(NSError(domain: "LocationPickerControllerErrorDomain",
+                                  code: 0,
+                                  userInfo: ["Reason": "Invalid coordinate"]))
             return
         }
 
-        if let success = self.success {
-            success(self.mapView.centerCoordinate)
-        }
+        self.success?(self.mapView.centerCoordinate)
 
         self.dismissViewControllerAnimated(true, completion: nil)
     }

--- a/LocationPickerController/LocationPickerController.swift
+++ b/LocationPickerController/LocationPickerController.swift
@@ -33,8 +33,8 @@ class LocationPickerController: UIViewController, MKMapViewDelegate, CLLocationM
 
     let locationManager: CLLocationManager = CLLocationManager()
 
-    var success: successClosure? = nil
-    var failure: failureClosure? = nil
+    var success: successClosure?
+    var failure: failureClosure?
 
     var isInitialized: Bool = false
 

--- a/LocationPickerController/LocationPickerController.swift
+++ b/LocationPickerController/LocationPickerController.swift
@@ -36,7 +36,7 @@ class LocationPickerController: UIViewController {
     var success: successClosure?
     var failure: failureClosure?
 
-    var isInitialized: Bool = false
+    private var isInitialized: Bool = false
 
     init(success: successClosure, failure: failureClosure? = nil) {
         self.success = success

--- a/LocationPickerController/LocationPickerController.swift
+++ b/LocationPickerController/LocationPickerController.swift
@@ -38,7 +38,7 @@ class LocationPickerController: UIViewController, MKMapViewDelegate, CLLocationM
 
     var isInitialized: Bool = false
 
-    init(success: successClosure, failure: failureClosure?) {
+    init(success: successClosure, failure: failureClosure? = nil) {
         self.success = success
         self.failure = failure
         super.init(nibName: nil, bundle: nil)

--- a/LocationPickerController/LocationPickerController.swift
+++ b/LocationPickerController/LocationPickerController.swift
@@ -25,7 +25,7 @@ extension UIBarButtonItem {
 typealias successClosure = (CLLocationCoordinate2D) -> Void
 typealias failureClosure = (NSError) -> Void
 
-class LocationPickerController: UIViewController, MKMapViewDelegate, CLLocationManagerDelegate {
+class LocationPickerController: UIViewController {
 
     var mapView: MKMapView!
     var pointAnnotation: MKPointAnnotation!
@@ -86,8 +86,11 @@ class LocationPickerController: UIViewController, MKMapViewDelegate, CLLocationM
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
+}
 
-    // MARK: - Internal methods
+// MARK: - Internal methods
+
+internal extension LocationPickerController {
 
     func didTapCancelButton() {
         self.dismissViewControllerAnimated(true, completion: nil)
@@ -96,8 +99,8 @@ class LocationPickerController: UIViewController, MKMapViewDelegate, CLLocationM
     func didTapDoneButton() {
         guard CLLocationCoordinate2DIsValid(self.mapView.centerCoordinate) else {
             self.failure?(NSError(domain: "LocationPickerControllerErrorDomain",
-                                  code: 0,
-                                  userInfo: ["Reason": "Invalid coordinate"]))
+                code: 0,
+                userInfo: ["Reason": "Invalid coordinate"]))
             return
         }
 
@@ -110,24 +113,31 @@ class LocationPickerController: UIViewController, MKMapViewDelegate, CLLocationM
         self.mapView.setCenterCoordinate(self.mapView.userLocation.coordinate, animated: true)
         self.currentButton.enabled = false
     }
+}
 
-    // MARK: - MKMapView delegate
+// MARK: - MKMapView delegate
 
+extension LocationPickerController: MKMapViewDelegate {
+    
     func mapView(mapView: MKMapView, regionWillChangeAnimated animated: Bool) {
         guard self.isInitialized else {
             return
         }
         self.currentButton.enabled = true
     }
-
+    
     func mapView(mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
         guard self.isInitialized else {
             return
         }
         self.pointAnnotation.coordinate = mapView.region.center
     }
+}
 
-    // MARK: - CLLocationManager delegate
+
+// MARK: - CLLocationManager delegate
+
+extension LocationPickerController: CLLocationManagerDelegate {
 
     func locationManager(manager: CLLocationManager, didChangeAuthorizationStatus status: CLAuthorizationStatus) {
         switch status {


### PR DESCRIPTION
このPull Requestは
- optionalの変数はnilになっているのでnil代入する必要はなく
- 引数の初期値がある場合は呼び出し側が省略できるのでoptionalのクロージャにはnilを明示
- optionalのクロージャはbindするよりoptional chaining的にそのまま呼び出してbindで二度同じ変数名を書かないでよいように
- （好みの問題でやってなかったのかもしれませんが）MARKで実装を分けるときはextensionで実装すると分かりやすいかと

もしよければ参考に :)
